### PR TITLE
Opinionated: Update checker

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -14,7 +14,7 @@
   pname = "claude-desktop";
   version = "0.7.7";
   srcExe = fetchurl {
-    url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe";
+    url = "https://storage.googleapis.com/download/storage/v1/b/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/o/nest-win-x64%2FClaude-Setup-x64.exe?generation=1734634165702331&alt=media";
     hash = "sha256-kzuvh0wl/saZlBHnpL0/EZItjsPpiX4kYrsd89A1sQo=";
   };
 in

--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -26,15 +26,15 @@
         builtins.trace "[1;31mNew ${objectName} generation found: ${objectGeneration} (created ${timeCreated})[0m" currentGeneration;
   bucketName = "osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97";
   objectName = "nest-win-x64%2fClaude-Setup-x64.exe";
-  currentGeneration = "1734634165702331";
+  currentGeneration = "1736347746447694";
 
   generation = ensureGeneration { inherit bucketName objectName currentGeneration; };
 
   pname = "claude-desktop";
-  version = "0.7.7";
+  version = "0.7.8";
   srcExe = fetchurl {
     url = "https://storage.googleapis.com/download/storage/v1/b/${bucketName}/o/${objectName}?generation=${generation}&alt=media";
-    hash = "sha256-kzuvh0wl/saZlBHnpL0/EZItjsPpiX4kYrsd89A1sQo=";
+    hash = "sha256-SOO1FkAfcOP50Z4YPyrrpSIi322gQdy9vk0CKdYjMwA=";
   };
 in
   stdenvNoCC.mkDerivation rec {

--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -11,10 +11,29 @@
   makeWrapper,
   patchy-cnb,
 }: let
+  ensureGeneration = { bucketName, objectName, currentGeneration }:
+    let
+      objectInfo = builtins.fromJSON (builtins.readFile (builtins.fetchurl {
+        url = "https://storage.googleapis.com/storage/v1/b/${bucketName}/o/${objectName}";
+        name = "info.json";
+      }));
+      objectGeneration = objectInfo.generation;
+      timeCreated = objectInfo.timeCreated;
+    in
+      if objectGeneration == currentGeneration then
+        currentGeneration
+      else
+        builtins.trace "[1;31mNew ${objectName} generation found: ${objectGeneration} (created ${timeCreated})[0m" currentGeneration;
+  bucketName = "osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97";
+  objectName = "nest-win-x64%2fClaude-Setup-x64.exe";
+  currentGeneration = "1734634165702331";
+
+  generation = ensureGeneration { inherit bucketName objectName currentGeneration; };
+
   pname = "claude-desktop";
   version = "0.7.7";
   srcExe = fetchurl {
-    url = "https://storage.googleapis.com/download/storage/v1/b/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/o/nest-win-x64%2FClaude-Setup-x64.exe?generation=1734634165702331&alt=media";
+    url = "https://storage.googleapis.com/download/storage/v1/b/${bucketName}/o/${objectName}?generation=${generation}&alt=media";
     hash = "sha256-kzuvh0wl/saZlBHnpL0/EZItjsPpiX4kYrsd89A1sQo=";
   };
 in


### PR DESCRIPTION
Pinned specific generation (matching 0.7.7) should ensure the hash matches downloaded binary.
Would alert if a new version is available on every rebuild:
![image](https://github.com/user-attachments/assets/0f4e7da1-9fd1-4485-9e5a-a3ff6c1cc9fc)

>[!CAUTION]
> This is likely a very non-idiomatic Nix approach.