### PR TITLE
Set `allowUnfree` in flake so package can be imported into other flakes without `--impure`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
   }: flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system: let
       pkgs = import nixpkgs {
         inherit system;
+        config.allowUnfree = true;
       };
     in {
       packages = rec {


### PR DESCRIPTION
Thanks for putting this flake together!

I set this on my fork to be able to add this to my nixos config. It should also address #7.