### PR TITLE
Add `claude-desktop-with-fhs`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ And then the following package to your `environment.systemPackages` or `home.pac
 inputs.claude-desktop.packages.${system}.claude-desktop
 ```
 
+If you would like to run [MCP servers with Claude Desktop](https://modelcontextprotocol.io/quickstart/user) on NixOS, use the `claude-desktop-with-fhs` package. This will allow running MCP servers with calls to `npx`, `uvx`, or `docker` (assuming docker is installed).
+```nix
+inputs.claude-desktop.packages.${system}.claude-desktop-with-fhs
+```
+
 ## Other distributions
 
 This repository only provides a Nix flake, and does not provide a package for e.g. Ubuntu, Fedora, or Arch Linux.

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,17 @@
         claude-desktop = pkgs.callPackage ./pkgs/claude-desktop.nix {
           inherit patchy-cnb;
         };
+        claude-desktop-with-fhs = pkgs.buildFHSEnv {
+          name = "claude-desktop";
+          targetPkgs = pkgs: with pkgs; [
+            docker
+            glibc
+            openssl
+            nodejs
+            uv
+          ];
+          runScript = "${claude-desktop}/bin/claude-desktop";
+        };
         default = claude-desktop;
       };
     });


### PR DESCRIPTION
On NixOS, using `claude-desktop-with-fhs` instead of `claude-desktop` enables support for using various MCP servers.

For non-NixOS users this isn't required, but can be used if you don't want to install `npm` or `uv` locally.