### PR TITLE
fix: update hash for new version

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -17,7 +17,7 @@
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=0.10.14";
-    hash = "sha256-NtEA27ZUVSi+LvLHoKUOASMVcO22r+QZ0+l46OMSRm8=";
+    hash = "sha256-RRXa1PCHBOMdSKcCFr4rmqzWBiA/ezSuz+mWhc0zbkE=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
This pull request updates the hash for the `Claude-Setup-x64.exe` file in the `pkgs/claude-desktop.nix` file to ensure integrity verification matches the latest version of the file.

Key change:

* [`pkgs/claude-desktop.nix`](diffhunk://#diff-151a3013895e82829c9788cb989c88ec78ec2f3fa44ab53f68147e526929f6eaL20-R20): Updated the `hash` value for the `srcExe` fetch operation to `sha256-RRXa1PCHBOMdSKcCFr4rmqzWBiA/ezSuz+mWhc0zbkE=` to reflect the updated file version.