### PR TITLE
fix: update version with hash

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -13,10 +13,10 @@
   perl
 }: let
   pname = "claude-desktop";
-  version = "0.10.14";
+  version = "0.10.38";
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
-    url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=0.10.14";
+    url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=0.10.38";
     hash = "sha256-RRXa1PCHBOMdSKcCFr4rmqzWBiA/ezSuz+mWhc0zbkE=";
   };
 in


### PR DESCRIPTION
Missed the version update in my previous commit

This pull request updates the version of the `claude-desktop` package in the `pkgs/claude-desktop.nix` file. 

Version update:

* Updated `version` from `0.10.14` to `0.10.38` and updated the corresponding URL to reflect the new version.