### PR TITLE
feat: build nix flake with action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: "NIXOS build flake"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Nix cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /nix/store
+            /nix/var/nix/db
+            /nix/var/nix/profiles
+          key: ${{ runner.os }}-nix-${{ hashFiles('vm/**/*.nix') }}
+          restore-keys: |
+            ${{ runner.os }}-nix-
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build Flake
+        run: |
+          nix build .


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for the NixOS flake. The workflow is triggered on pushes to the `main` branch and pull requests, and it sets up a Nix cache, installs Nix, and builds the flake.

### New GitHub Actions workflow for NixOS flake:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R1-R33): Added a new workflow named "NIXOS build flake" to automate the build process. It includes steps to check out the repository, set up a Nix cache, install Nix using the `cachix/install-nix-action`, and build the flake using `nix build`. The workflow is triggered on `push` events to the `main` branch and on pull requests. :)