### PR TITLE
fix: update exe hash

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -13,11 +13,11 @@
   perl
 }: let
   pname = "claude-desktop";
-  version = "0.10.38";
+  version = "0.11.4";
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=0.10.38";
-    hash = "sha256-RRXa1PCHBOMdSKcCFr4rmqzWBiA/ezSuz+mWhc0zbkE=";
+    hash = "sha256-7zz2JWI0Ozi976XaSSALcyEKPbIAHUSpGIgRkZvWf5U=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
- Update sha256 hash otherwise we use Nix cached version
- Update version variable otherwise it fails to find the nupkg file