### PR TITLE
Update to 0.12.20

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -13,11 +13,11 @@
   perl
 }: let
   pname = "claude-desktop";
-  version = "0.12.16";
+  version = "0.12.20";
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-5XWl5ADNBOkVHHv76VFRbqC2jxSpaKUXfuY6WAuaLKg=";
+    hash = "sha256-NjXoZQJiazT+AdiUUsVKiNIjkRIql8O3mc6/tfiUuN8=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
This pull request updates the version and hash for the `claude-desktop` package in the `pkgs/claude-desktop.nix` file.

Key changes:

* Updated the `version` from `"0.12.16"` to `"0.12.20"`.
* Updated the `hash` to match the new version's executable file (`sha256-NjXoZQJiazT+AdiUUsVKiNIjkRIql8O3mc6/tfiUuN8=`).