### PR TITLE
Update Claude Desktop to 0.12.55

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -13,11 +13,11 @@
   perl
 }: let
   pname = "claude-desktop";
-  version = "0.12.49";
+  version = "0.12.55";
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-uQDHaxl2qlufLxKN83cObawtG6D8x/+H+hDgYlv+Dvc=";
+    hash = "sha256-hmnvrNKwj2Zx2e2YpVBoEQRJC4bJLjJBFIr6NipNKTg=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
## Summary
Updates Claude Desktop from version 0.12.49 to 0.12.55 with the corresponding hash update.

## Changes
- Bump version from 0.12.49 to 0.12.55
- Update hash to match new version

## Testing
Built and tested locally with `nix build`.

Fixes #55