### PR TITLE
Fix missing desktop file and icon mismatch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,8 @@
     self,
     nixpkgs,
     flake-utils,
-  }: flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system: let
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux" "aarch64-linux"] (system: let
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
@@ -23,14 +24,24 @@
         };
         claude-desktop-with-fhs = pkgs.buildFHSEnv {
           name = "claude-desktop";
-          targetPkgs = pkgs: with pkgs; [
-            docker
-            glibc
-            openssl
-            nodejs
-            uv
-          ];
+          targetPkgs = pkgs:
+            with pkgs; [
+              docker
+              glibc
+              openssl
+              nodejs
+              uv
+            ];
           runScript = "${claude-desktop}/bin/claude-desktop";
+          extraInstallCommands = ''
+            # Copy desktop file from the claude-desktop package
+            mkdir -p $out/share/applications
+            cp ${claude-desktop}/share/applications/claude.desktop $out/share/applications/
+
+            # Copy icons
+            mkdir -p $out/share/icons
+            cp -r ${claude-desktop}/share/icons/* $out/share/icons/
+          '';
         };
         default = claude-desktop;
       };

--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -35,13 +35,14 @@ in
     ];
 
     desktopItem = makeDesktopItem {
-      name = "claude-desktop";
+      name = "claude";
       exec = "claude-desktop %u";
-      icon = "claude-desktop";
+      icon = "claude";
       type = "Application";
       terminal = false;
       desktopName = "Claude";
       genericName = "Claude Desktop";
+      startupWMClass = "claude";
       categories = [
         "Office"
         "Utility"
@@ -164,7 +165,7 @@ in
 
       # Install .desktop file
       mkdir -p $out/share/applications
-      install -Dm0644 {${desktopItem},$out}/share/applications/$pname.desktop
+      install -Dm0644 ${desktopItem}/share/applications/claude.desktop $out/share/applications/claude.desktop
 
       # Create wrapper
       mkdir -p $out/bin


### PR DESCRIPTION
Hi there! 😄 👋🏻 - thanks for the project. This should fix up a few desktop icon issues.

---

- Add desktop file to FHS wrapper via extraInstallCommands
- Copy icons from claude-desktop package to FHS wrapper
- Add StartupWMClass=claude to desktop file for window matching
- Rename desktop file from claude-desktop.desktop to claude.desktop
  to match Wayland app ID requirements
- Update installation paths to use the new claude.desktop filename

On GNOME/Wayland, the desktop file basename must match the app ID
for proper window-to-icon association. This ensures the Claude icon
appears correctly in both the application launcher and window switcher.

Fixes #48