### PR TITLE
fix: correct hash for claude-desktop v0.12.129 and improve nupkg discovery

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -17,7 +17,7 @@
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-ISyVjtr9vGzCqq7oaDQd6h9kC7iumyo38z9VjuVCsu4=";
+    hash = "sha256-R37gvNevAvHx/7FfWkrRIJ19THVbV0VVD8i7JMUkiuM=";
   };
 in
   stdenvNoCC.mkDerivation rec {
@@ -59,7 +59,17 @@ in
 
       # Extract installer exe, and nupkg within it
       7z x -y ${srcExe}
-      7z x -y "AnthropicClaude-${version}-full.nupkg"
+      
+      # Find and extract the nupkg file (filename may vary)
+      ls -la
+      NUPKG_FILE=$(find . -name "*.nupkg" -type f | head -1)
+      if [ -z "$NUPKG_FILE" ]; then
+        echo "Error: No .nupkg file found"
+        find . -name "*Claude*" -o -name "*.nupkg" -o -name "*.zip"
+        exit 1
+      fi
+      echo "Found nupkg file: $NUPKG_FILE"
+      7z x -y "$NUPKG_FILE"
 
       # Package the icons from claude.exe
       wrestool -x -t 14 lib/net45/claude.exe -o claude.ico


### PR DESCRIPTION
- Updated hash from ISyVjtr9vGzCqq7oaDQd6h9kC7iumyo38z9VjuVCsu4= to R37gvNevAvHx/7FfWkrRIJ19THVbV0VVD8i7JMUkiuM= (the actual hash)
- Made nupkg file discovery more flexible to handle installer structure changes
- Fixes build failures due to hash mismatch in commit 76d8220


P.S This stuff vibe coded, worked for me so figured I could PR