### PR TITLE
fix: update exe hash for v0.13.19

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -13,11 +13,11 @@
   perl
 }: let
   pname = "claude-desktop";
-  version = "0.13.11";
+  version = "0.13.19";
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-R37gvNevAvHx/7FfWkrRIJ19THVbV0VVD8i7JMUkiuM=";
+    hash = "sha256-DwCgTSBpK28sRCBUBBatPsaBZQ+yyLrJbAriSkf1f8E=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
Bump exe version and update the hash

Resolves #70