### PR TITLE
fix: correct hash mismatch for claude-desktop v0.13.19

### DIFF
--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -17,7 +17,7 @@
   srcExe = fetchurl {
     # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
     url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-DwCgTSBpK28sRCBUBBatPsaBZQ+yyLrJbAriSkf1f8E=";
+    hash = "sha256-U7jpTk8pU7SUHKxTomQ3BLjspUsNU2r8fEWktaviYj4=";
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
`Fixes hash mismatch error preventing Claude Desktop installation for v0.13.19

Updated hash from:
sha256-DwCgTSBpK28sRCBUBBatPsaBZQ+yyLrJbAriSkf1f8E=

To:
sha256-U7jpTk8pU7SUHKxTomQ3BLjspUsNU2r8fEWktaviYj4=

Hash verified with nix-prefetch-url and tested locally.
Resolves build failures during nixos-rebuild.`